### PR TITLE
Add initialization error handling for app startup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-	preset: 'ts-jest',
-	testEnvironment: 'node',
-	testMatch: ['**/drugrunner/**/*.test.ts'],
+        preset: 'ts-jest',
+        testEnvironment: 'node',
+        testMatch: ['**/__tests__/**/*.test.ts', '**/drugrunner/**/*.test.ts'],
+        moduleNameMapper: {
+                '^@/(.*)$': '<rootDir>/src/$1',
+        },
 };

--- a/src/__tests__/initErrorFormatter.test.ts
+++ b/src/__tests__/initErrorFormatter.test.ts
@@ -1,0 +1,23 @@
+import { formatInitError } from '@/helpers/initError';
+
+describe('formatInitError', () => {
+        it('returns the message from an Error instance', () => {
+                const error = new Error('failed to connect');
+
+                expect(formatInitError(error)).toBe('failed to connect');
+        });
+
+        it('returns the provided string message', () => {
+                expect(formatInitError('custom failure')).toBe('custom failure');
+        });
+
+        it('serialises plain objects to provide context', () => {
+                expect(formatInitError({ reason: 'timeout', code: 504 })).toBe('{"reason":"timeout","code":504}');
+        });
+
+        it('falls back to a friendly default when given unusable input', () => {
+                expect(formatInitError(undefined)).toBe(
+                        'An unexpected error prevented Blogchain from starting. Please retry or reload the page.',
+                );
+        });
+});

--- a/src/components/InitializationError.vue
+++ b/src/components/InitializationError.vue
@@ -1,0 +1,75 @@
+<template>
+  <main class="min-h-screen bg-gray-50 text-gray-900 flex items-center justify-center px-4">
+    <section
+      class="w-full max-w-2xl bg-white shadow-xl rounded-2xl border border-gray-100 p-8 space-y-6"
+      role="alert"
+      aria-live="assertive"
+    >
+      <header class="flex items-center gap-3 text-red-700">
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 border border-red-100">
+          <svg
+            aria-hidden="true"
+            class="h-5 w-5 text-red-600"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          </svg>
+        </span>
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-wide text-red-600">Startup issue</p>
+          <h1 class="text-2xl font-bold">We could not start Blogchain</h1>
+        </div>
+      </header>
+
+      <p class="text-base leading-relaxed text-gray-700">
+        Something went wrong while loading the application. Please check your connection and try again. If the problem
+        persists, contact support with the details below so we can investigate quickly.
+      </p>
+
+      <div class="rounded-xl bg-gray-50 border border-gray-200 p-4" data-testid="initialization-error-details">
+        <p class="text-sm font-semibold text-gray-800">Error details</p>
+        <p class="mt-1 text-sm text-gray-700 break-words" data-testid="initialization-error-message">
+          {{ errorMessage }}
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex gap-3">
+          <button
+            type="button"
+            class="inline-flex items-center justify-center rounded-lg bg-red-600 px-4 py-2 text-white font-semibold shadow hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            @click="$emit('retry')"
+          >
+            Retry startup
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2 text-gray-900 font-semibold border border-gray-300 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            @click="reloadPage"
+          >
+            Reload page
+          </button>
+        </div>
+        <p class="text-sm text-gray-600">
+          Need help? <a class="text-red-700 underline" href="mailto:support@capsule.social">support@capsule.social</a>
+        </p>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    errorMessage: string;
+  }>(),
+  {
+    errorMessage: 'An unexpected error occurred while starting Blogchain.',
+  },
+);
+
+const reloadPage = () => window.location.reload();
+</script>

--- a/src/helpers/initError.ts
+++ b/src/helpers/initError.ts
@@ -1,0 +1,25 @@
+const DEFAULT_INITIALIZATION_ERROR =
+        'An unexpected error prevented Blogchain from starting. Please retry or reload the page.';
+
+export function formatInitError(error: unknown): string {
+        if (error instanceof Error) {
+                return error.message || DEFAULT_INITIALIZATION_ERROR;
+        }
+
+        if (typeof error === 'string') {
+                return error.trim() || DEFAULT_INITIALIZATION_ERROR;
+        }
+
+        if (typeof error === 'object' && error !== null) {
+                try {
+                        const serialised = JSON.stringify(error);
+                        return serialised === '{}' ? DEFAULT_INITIALIZATION_ERROR : serialised;
+                } catch (serialisationError) {
+                        // eslint-disable-next-line no-console
+                        console.error('Failed to serialise initialization error', serialisationError);
+                        return DEFAULT_INITIALIZATION_ERROR;
+                }
+        }
+
+        return DEFAULT_INITIALIZATION_ERROR;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,29 @@ import VueLazyLoad from 'vue3-lazyload';
 import App from './App.vue';
 import './index.css';
 import router from './router';
+import InitializationError from './components/InitializationError.vue';
+import { formatInitError } from './helpers/initError';
 import { initBackend } from './plugins/backend';
 
 const pinia = createPinia();
 pinia.use(piniaPluginPersistedstate);
 const metaManager = createMetaManager();
 
-// Here if it errors out, we need to expose the error, maybe render a dedicated error page?
-initBackend().then(() => {
-	createApp(App).use(pinia).use(router).use(metaManager).use(VueLazyLoad).mount('#app');
-});
+const mountApp = () =>
+        createApp(App).use(pinia).use(router).use(metaManager).use(VueLazyLoad).mount('#app');
+
+const mountInitializationError = (error: unknown) =>
+        createApp(InitializationError, {
+                errorMessage: formatInitError(error),
+                onRetry: () => window.location.reload(),
+        }).mount('#app');
+
+initBackend()
+        .then(mountApp)
+        .catch((error: unknown) => {
+                // Provide a user-facing error surface when bootstrapping fails so the app
+                // does not silently render a blank screen.
+                // eslint-disable-next-line no-console
+                console.error('Failed to initialise Blogchain frontend', error);
+                mountInitializationError(error);
+        });


### PR DESCRIPTION
## Summary
- show a user-friendly fallback screen when the frontend fails to initialize
- normalize initialization errors before rendering them to the user
- expand Jest configuration and add tests for the error formatting helper

## Testing
- yarn test:jest --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fac9aaed883338e4dda250458c79c)